### PR TITLE
Update timer.c

### DIFF
--- a/timer.c
+++ b/timer.c
@@ -45,7 +45,7 @@ int msgdecay = 0;
 #..catch_timer().#
 ##################
 */
-static void catch_timer(int signum)
+static void catch_timer(void)
 {
     timer_ticks++;
     gettimeofday(&current_snap,NULL);


### PR DESCRIPTION
catch_timer no longer returns int signum, which was never referenced and made mipspro cry.